### PR TITLE
Send mail with %Mail.Message{} and Multiple recipients for email

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Send, receive and process emails.
 
 ## Example:
 
+### POP3
 ```elixir
 alias Mailroom.POP3
 
@@ -17,6 +18,31 @@ client
 end)
 :ok = POP3.reset(client)
 :ok = POP3.close(client)
+```
+
+### SMTP
+```elixir
+  alias Mailroom.SMTP
+  
+  def config, do:
+    [
+      username: System.get_env("EMAIL_USER"),
+      password: System.get_env("EMAIL_PASS"),
+      port: 587
+    ]
+  
+  def test_email() do
+    {:ok, client} = SMTP.connect("smtp.example.com", config()) 
+
+    Mail.build()
+    |> Mail.put_from("user1@example.com")
+    |> Mail.put_to(["user2@example.com", "user3@example.com"])
+    |> Mail.put_subject("This is only a test")
+    |> Mail.put_text("Write your message here!!!")
+    |> SMTP.send(client)
+
+    SMTP.quit(client)
+  end
 ```
 
 ## Installation

--- a/lib/mailroom/smtp.ex
+++ b/lib/mailroom/smtp.ex
@@ -277,7 +277,9 @@ defmodule Mailroom.SMTP do
     message
     |> String.split(~r/\r\n/)
     |> Enum.each(fn line ->
-      :ok = Socket.send(socket, [line, "\r\n"])
+      ## Escape period at start of line (rfc5321 4.5.2)
+      escaped_line = String.replace(line, ~r/^\./, "..")
+      :ok = Socket.send(socket, [escaped_line, "\r\n"])
     end)
 
     :ok

--- a/test/mailroom/smtp_test.exs
+++ b/test/mailroom/smtp_test.exs
@@ -30,7 +30,7 @@ defmodule Mailroom.SMTPTest do
     {:ok, client} = SMTP.connect(server.address, port: server.port)
     SMTP.quit(client)
   end
-
+  
   test "send mail" do
     server = TestServer.start()
 
@@ -81,6 +81,56 @@ defmodule Mailroom.SMTPTest do
 
     {:ok, client} = SMTP.connect(server.address, port: server.port)
     :ok = SMTP.send_message(client, "me@localhost", "you@localhost", msg)
+    SMTP.quit(client)
+  end
+
+  test "send mail with Mail module" do
+    email =
+      Mail.build()
+      |> Mail.put_from("me@example.com")
+      |> Mail.put_to("you@example.com")
+      |> Mail.put_subject("Test message")
+      |> Mail.put_text("This is a test message")
+    
+    msg = Mail.Renderers.RFC2822.render(email)
+    lines = String.split(msg, "\r\n") |> Enum.map(&(&1 <> "\r\n"))
+
+    server = TestServer.start()
+    TestServer.expect(server, fn expectations ->
+      expectations
+      |> TestServer.on(
+        :connect,
+        "220 myserver.com.\r\n"
+      )
+      |> TestServer.on(
+        "EHLO #{SMTP.fqdn()}\r\n",
+        "250-myserver.com\r\n250-SIZE\r\n250 HELP\r\n"
+      )
+      |> TestServer.on(
+        "MAIL FROM: <me@example.com>\r\n",
+        "250 OK\r\n"
+      )
+      |> TestServer.on(
+        "RCPT TO: <you@example.com>\r\n",
+        "250 OK\r\n"
+      )
+      |> TestServer.on(
+        "DATA\r\n",
+        "354 Send message content; end with <CRLF>.<CRLF>\r\n"
+      )
+      |> TestServer.on(
+        lines ++ [".\r\n"],
+        "250 OK\r\n"
+      )
+      |> TestServer.on(
+        "QUIT\r\n",
+        "221 Bye\r\n"
+      )
+    end)
+
+    {:ok, client} = SMTP.connect(server.address, port: server.port)
+
+    :ok = SMTP.send(email, client)
     SMTP.quit(client)
   end
 


### PR DESCRIPTION
This PR implements the `Mailroom.SMTP.send` function that can take a `%Mail.Message{}` as an argument. The map is used to send all the required commands to the Mail Submission Agent. 

The responses from the MSA are verfied to make sure that there are no errors. When an error response is caught, the session is closed and the EMail is not successfully sent. The `send` function exits with an error tuple.

When Email is sent successfully, `send` exits with a `:ok`.
The same error handling is made for `send_message` function too.

PS. I have also implemented the escaping of the a period(`.`) at start of line according to [rfc5321 4.5.2](https://tools.ietf.org/html/rfc5321#section-4.5.2). I can make a seperate PR for this if that is necessary. This can be found in ce90849.