### PR TITLE
Improvements

### DIFF
--- a/lib/mailroom/imap.ex
+++ b/lib/mailroom/imap.ex
@@ -109,7 +109,7 @@ defmodule Mailroom.IMAP do
     do: GenServer.call(pid, {:select, mailbox_name}) && pid
 
   def examine(pid, mailbox_name),
-    do: GenServer.call(pid, {:examine, mailbox_name})
+    do: GenServer.call(pid, {:examine, mailbox_name}) && pid
 
   def list(pid, reference \\ "", mailbox_name \\ "*"),
     do: GenServer.call(pid, {:list, reference, mailbox_name})

--- a/lib/mailroom/imap.ex
+++ b/lib/mailroom/imap.ex
@@ -433,7 +433,7 @@ defmodule Mailroom.IMAP do
 
   def handle_info({:ssl_closed, _}, state) do
     Logger.warn("SSL closed")
-    {:stop, :ssl_closed, state}
+    {:stop, {:shutdown, :ssl_closed}, state}
   end
 
   defp cancel_idle(socket, timer) do

--- a/lib/mailroom/imap/envelope.ex
+++ b/lib/mailroom/imap/envelope.ex
@@ -1,5 +1,5 @@
 defmodule Mailroom.IMAP.Envelope do
-  defstruct ~w[date subject from sender reply_to to cc bcc in_reply_to message_id]a
+  defstruct ~w[date date_string subject from sender reply_to to cc bcc in_reply_to message_id]a
 
   defmodule Address do
     defstruct ~w[name mailbox_name host_name email]a
@@ -39,7 +39,7 @@ defmodule Mailroom.IMAP.Envelope do
   def new(list) do
     [date, subject, from, sender, reply_to, to, cc, bcc, in_reply_to, message_id] = list
 
-    date = Mail.Parsers.RFC2822.erl_from_timestamp(date)
+    erlang_date = Mail.Parsers.RFC2822.erl_from_timestamp(date)
     from = parse_addresses(from)
     sender = parse_addresses(sender)
     reply_to = parse_addresses(reply_to)
@@ -48,7 +48,8 @@ defmodule Mailroom.IMAP.Envelope do
     bcc = parse_addresses(bcc)
 
     %__MODULE__{
-      date: date,
+      date_string: date,
+      date: erlang_date,
       subject: subject,
       from: from,
       sender: sender,

--- a/test/mailroom/imap_test.exs
+++ b/test/mailroom/imap_test.exs
@@ -380,6 +380,46 @@ defmodule Mailroom.IMAPTest do
     IMAP.logout(client)
   end
 
+  test "UID SEARCH" do
+    server = TestServer.start(ssl: true)
+
+    TestServer.expect(server, fn expectations ->
+      expectations
+      |> TestServer.tagged(:connect, "* OK IMAP ready\r\n")
+      |> TestServer.tagged("LOGIN \"test@example.com\" \"P@55w0rD\"\r\n", [
+        "* CAPABILITY (IMAPrev4)\r\n",
+        "OK test@example.com authenticated (Success)\r\n"
+      ])
+      |> TestServer.tagged("SELECT INBOX\r\n", [
+        "* FLAGS (\\Flagged \\Draft \\Deleted \\Seen)\r\n",
+        "* OK [PERMANENTFLAGS (\\Flagged \\Draft \\Deleted \\Seen \\*)] Flags permitted\r\n",
+        "* 2 EXISTS\r\n",
+        "* 1 RECENT\r\n",
+        "OK [READ-WRITE] INBOX selected. (Success)\r\n"
+      ])
+      |> TestServer.tagged("UID SEARCH UNSEEN\r\n", ["* SEARCH 1 2 4 6 7\r\n", "OK Success\r\n"])
+      |> TestServer.tagged("LOGOUT\r\n", [
+        "* BYE We're out of here\r\n",
+        "OK Logged out\r\n"
+      ])
+    end)
+
+    assert {:ok, client} =
+             IMAP.connect(server.address, "test@example.com", "P@55w0rD",
+               port: server.port,
+               ssl: true,
+               debug: @debug
+             )
+
+    {:ok, msgs} =
+      client
+      |> IMAP.select(:inbox)
+      |> IMAP.uid_search("UNSEEN")
+
+    assert msgs == [1, 2, 4, 6, 7]
+    IMAP.logout(client)
+  end
+
   test "SEARCH with enumerator function" do
     server = TestServer.start(ssl: true)
 

--- a/test/mailroom/imap_test.exs
+++ b/test/mailroom/imap_test.exs
@@ -1112,6 +1112,7 @@ defmodule Mailroom.IMAPTest do
                   bcc: [],
                   cc: [],
                   date: {{2019, 6, 27}, {12, 0, 1}},
+                  date_string: "Thu, 27 Jun 2019 12:00:01 +0200",
                   from: [
                     %Mailroom.IMAP.Envelope.Address{
                       email: "john@example.com",
@@ -1200,6 +1201,7 @@ defmodule Mailroom.IMAPTest do
                   bcc: [],
                   cc: [],
                   date: {{2019, 6, 27}, {12, 0, 1}},
+                  date_string: "Thu, 27 Jun 2019 12:00:01 +0200",
                   from: [
                     %Mailroom.IMAP.Envelope.Address{
                       email: "john@example.com",

--- a/test/support/test_server.ex
+++ b/test/support/test_server.ex
@@ -105,7 +105,7 @@ defmodule Mailroom.TestServer do
         | @tcp_opts
       ]
 
-      {:ok, socket} = :ssl.handshake(socket, opts, 1_000)
+      {:ok, socket} = :ssl.ssl_accept(socket, opts, 1_000)
       socket
     else
       socket
@@ -206,7 +206,7 @@ defmodule Mailroom.TestServer do
 
   defp accept_connection({:sslsocket, _, _} = socket) do
     {:ok, socket} = :ssl.transport_accept(socket)
-    {:ok, _} = :ssl.handshake(socket, 1_000)
+    :ok = :ssl.ssl_accept(socket, 1_000)
     {:ok, socket}
   end
 

--- a/test/support/test_server.ex
+++ b/test/support/test_server.ex
@@ -105,7 +105,7 @@ defmodule Mailroom.TestServer do
         | @tcp_opts
       ]
 
-      {:ok, socket} = :ssl.ssl_accept(socket, opts, 1_000)
+      {:ok, socket} = :ssl.handshake(socket, opts, 1_000)
       socket
     else
       socket
@@ -206,7 +206,7 @@ defmodule Mailroom.TestServer do
 
   defp accept_connection({:sslsocket, _, _} = socket) do
     {:ok, socket} = :ssl.transport_accept(socket)
-    :ok = :ssl.ssl_accept(socket, 1_000)
+    {:ok, _} = :ssl.handshake(socket, 1_000)
     {:ok, socket}
   end
 


### PR DESCRIPTION
Added two imap command, `UID SEARCH` and `UID FETCH` to search for email using `uid` instead of `sequential number` which is safer.
Added an option to the flags commands to possibly swith to use `UID STORE` instead of `STORE`.
Also added a new key to the mail result containing the received date with a more friendly format which can be easily parsed to a `DateTime.t()` with `Timex`.