### PR TITLE
Migrate from Mix.Config to Elixir's Config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,5 @@
 # This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
@@ -27,5 +26,5 @@ use Mix.Config
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
 #
-environment_config = Path.join([__DIR__, "#{Mix.env()}.exs"])
-if File.exists?(environment_config), do: import_config("#{Mix.env()}.exs")
+environment_config = Path.join([__DIR__, "#{config_env()}.exs"])
+if File.exists?(environment_config), do: import_config("#{config_env()}.exs")

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :ex_unit,
   refute_receive_timeout: 900,


### PR DESCRIPTION
Resolves a deprecation warning when compiling mailroom. Migrated according to the [procedure in Elixir.Config docs](https://hexdocs.pm/elixir/Config.html#module-migrating-from-use-mix-config).