### PR TITLE
Add ssl_opts for IMAP, POP3, and SMTP

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,14 @@ jobs:
             - .mix
           key: v2-dependencies-{{ checksum "mix.lock" }}
       - run: mix test --exclude not_implemented
-      - run: mix format --check-formatted
+      - when:
+          condition:
+            not:
+              matches:
+                pattern: "^1\\.(?:9|10|11)\\.\\d+$"
+                value: <<parameters.elixir_version>>
+          steps:
+            - run: mix format --check-formatted
 workflows:
   test_versions:
     jobs:

--- a/lib/mailroom/pop3.ex
+++ b/lib/mailroom/pop3.ex
@@ -37,7 +37,9 @@ defmodule Mailroom.POP3 do
   """
   def connect(server, username, password, options \\ []) do
     opts = parse_opts(options)
-    {:ok, socket} = Socket.connect(server, opts.port, ssl: opts.ssl, debug: opts.debug)
+
+    {:ok, socket} =
+      Socket.connect(server, opts.port, ssl: opts.ssl, debug: opts.debug, ssl_opts: opts.ssl_opts)
 
     case login(socket, username, password) do
       :ok -> {:ok, socket}
@@ -45,13 +47,16 @@ defmodule Mailroom.POP3 do
     end
   end
 
-  defp parse_opts(opts, acc \\ %{ssl: false, port: nil, debug: false})
+  defp parse_opts(opts, acc \\ %{ssl: false, port: nil, debug: false, ssl_opts: []})
 
   defp parse_opts([], acc),
     do: set_default_port(acc)
 
   defp parse_opts([{:ssl, ssl} | tail], acc),
     do: parse_opts(tail, Map.put(acc, :ssl, ssl))
+
+  defp parse_opts([{:ssl_opts, ssl_opts} | tail], acc),
+    do: parse_opts(tail, Map.put(acc, :ssl_opts, ssl_opts))
 
   defp parse_opts([{:port, port} | tail], acc),
     do: parse_opts(tail, Map.put(acc, :port, port))

--- a/lib/mailroom/smtp.ex
+++ b/lib/mailroom/smtp.ex
@@ -3,7 +3,9 @@ defmodule Mailroom.SMTP do
 
   def connect(server, options \\ []) do
     opts = parse_opts(options)
-    {:ok, socket} = Socket.connect(server, opts.port, ssl: opts.ssl, debug: opts.debug)
+
+    {:ok, socket} =
+      Socket.connect(server, opts.port, ssl: opts.ssl, debug: opts.debug, ssl_opts: opts.ssl_opts)
 
     with {:ok, _banner} <- read_banner(socket),
          {:ok, extensions} <- greet(socket),
@@ -15,11 +17,14 @@ defmodule Mailroom.SMTP do
     end
   end
 
-  defp parse_opts(opts, acc \\ %{ssl: false, port: 25, debug: false})
+  defp parse_opts(opts, acc \\ %{ssl: false, port: 25, debug: false, ssl_opts: []})
   defp parse_opts([], acc), do: acc
 
   defp parse_opts([{:ssl, ssl} | tail], acc),
     do: parse_opts(tail, Map.put(acc, :ssl, ssl))
+
+  defp parse_opts([{:ssl_opts, ssl_opts} | tail], acc),
+    do: parse_opts(tail, Map.put(acc, :ssl_opts, ssl_opts))
 
   defp parse_opts([{:port, port} | tail], acc),
     do: parse_opts(tail, Map.put(acc, :port, port))

--- a/test/mailroom/imap_test.exs
+++ b/test/mailroom/imap_test.exs
@@ -25,6 +25,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "P@55w0rD",
                port: server.port,
                ssl: false,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
 
@@ -47,6 +48,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "wrong",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
   end
@@ -67,6 +69,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "p!@#$%^&*()\"",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
   end
@@ -87,6 +90,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "P@55w0rD",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
 
@@ -112,6 +116,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "P@55w0rD",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
   end
@@ -143,6 +148,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "P@55w0rD",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
 
@@ -181,6 +187,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "P@55w0rD",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
 
@@ -219,6 +226,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "P@55w0rD",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
 
@@ -258,6 +266,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "P@55w0rD",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
 
@@ -293,6 +302,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "P@55w0rD",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
 
@@ -328,6 +338,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "P@55w0rD",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
 
@@ -368,6 +379,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "P@55w0rD",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
 
@@ -408,6 +420,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "P@55w0rD",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
 
@@ -448,6 +461,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "P@55w0rD",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
 
@@ -499,6 +513,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "P@55w0rD",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
 
@@ -547,6 +562,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "P@55w0rD",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
 
@@ -601,6 +617,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "P@55w0rD",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
 
@@ -647,6 +664,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "P@55w0rD",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
 
@@ -790,6 +808,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "P@55w0rD",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
 
@@ -1136,6 +1155,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "P@55w0rD",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
 
@@ -1179,6 +1199,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "P@55w0rD",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
 
@@ -1268,6 +1289,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "P@55w0rD",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
 
@@ -1363,6 +1385,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "P@55w0rD",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
 
@@ -1407,6 +1430,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "P@55w0rD",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
 
@@ -1454,6 +1478,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "P@55w0rD",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
 
@@ -1505,6 +1530,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "P@55w0rD",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
 
@@ -1543,6 +1569,7 @@ defmodule Mailroom.IMAPTest do
              IMAP.connect(server.address, "test@example.com", "P@55w0rD",
                port: server.port,
                ssl: true,
+               ssl_opts: [verify: :verify_none],
                debug: @debug
              )
 

--- a/test/mailroom/pop3_test.exs
+++ b/test/mailroom/pop3_test.exs
@@ -21,7 +21,8 @@ defmodule Mailroom.POP3Test do
       assert {:ok, _client} =
                POP3.connect(server.address, "test@example.com", "P@55w0rD",
                  port: server.port,
-                 ssl: unquote(ssl)
+                 ssl: unquote(ssl),
+                 ssl_opts: [verify: :verify_none]
                )
     end
 
@@ -38,7 +39,8 @@ defmodule Mailroom.POP3Test do
       assert {:error, :authentication, "[AUTH] Authentication failure."} ==
                POP3.connect(server.address, "test@example.com", "P@55w0rD",
                  port: server.port,
-                 ssl: unquote(ssl)
+                 ssl: unquote(ssl),
+                 ssl_opts: [verify: :verify_none]
                )
     end
 
@@ -56,7 +58,8 @@ defmodule Mailroom.POP3Test do
       assert {:ok, client} =
                POP3.connect(server.address, "test@example.com", "P@55w0rD",
                  port: server.port,
-                 ssl: unquote(ssl)
+                 ssl: unquote(ssl),
+                 ssl_opts: [verify: :verify_none]
                )
 
       assert POP3.stat(client) == {1, 123}
@@ -76,7 +79,8 @@ defmodule Mailroom.POP3Test do
       {:ok, client} =
         POP3.connect(server.address, "test@example.com", "P@55w0rD",
           port: server.port,
-          ssl: unquote(ssl)
+          ssl: unquote(ssl),
+          ssl_opts: [verify: :verify_none]
         )
 
       assert client |> POP3.list() == [{1, 121}, {2, 113}]
@@ -116,7 +120,8 @@ defmodule Mailroom.POP3Test do
       {:ok, client} =
         POP3.connect(server.address, "test@example.com", "P@55w0rD",
           port: server.port,
-          ssl: unquote(ssl)
+          ssl: unquote(ssl),
+          ssl_opts: [verify: :verify_none]
         )
 
       {2, 234} = POP3.stat(client)
@@ -139,7 +144,8 @@ defmodule Mailroom.POP3Test do
       {:ok, client} =
         POP3.connect(server.address, "test@example.com", "P@55w0rD",
           port: server.port,
-          ssl: unquote(ssl)
+          ssl: unquote(ssl),
+          ssl_opts: [verify: :verify_none]
         )
 
       {2, 234} = POP3.stat(client)
@@ -160,7 +166,8 @@ defmodule Mailroom.POP3Test do
       assert {:ok, client} =
                POP3.connect(server.address, "test@example.com", "P@55w0rD",
                  port: server.port,
-                 ssl: unquote(ssl)
+                 ssl: unquote(ssl),
+                 ssl_opts: [verify: :verify_none]
                )
 
       assert POP3.reset(client) == :ok
@@ -180,7 +187,8 @@ defmodule Mailroom.POP3Test do
       assert {:ok, client} =
                POP3.connect(server.address, "test@example.com", "P@55w0rD",
                  port: server.port,
-                 ssl: unquote(ssl)
+                 ssl: unquote(ssl),
+                 ssl_opts: [verify: :verify_none]
                )
 
       assert POP3.quit(client) == :ok

--- a/test/mailroom/smtp_test.exs
+++ b/test/mailroom/smtp_test.exs
@@ -112,7 +112,9 @@ defmodule Mailroom.SMTPTest do
       )
     end)
 
-    {:ok, client} = SMTP.connect(server.address, port: server.port)
+    {:ok, client} =
+      SMTP.connect(server.address, port: server.port, ssl_opts: [verify: :verify_none])
+
     SMTP.quit(client)
   end
 
@@ -260,7 +262,12 @@ defmodule Mailroom.SMTPTest do
     end)
 
     {:ok, client} =
-      SMTP.connect(server.address, port: server.port, username: "username", password: "password")
+      SMTP.connect(server.address,
+        port: server.port,
+        username: "username",
+        password: "password",
+        ssl_opts: [verify: :verify_none]
+      )
 
     SMTP.quit(client)
   end


### PR DESCRIPTION
This will solve the problem of #13 and moves the validation of #15 to the choice of those who use the library.