### PR TITLE
Add UID support for reliable email identification

### DIFF
--- a/lib/mailroom/imap.ex
+++ b/lib/mailroom/imap.ex
@@ -212,6 +212,39 @@ defmodule Mailroom.IMAP do
   def set_flags(pid, number_or_range, flags, opts \\ []),
     do: GenServer.call(pid, {:set_flags, number_or_range, flags, opts}) && pid
 
+  @doc """
+  Remove flags from messages using UIDs instead of sequence numbers.
+
+  ## Examples:
+
+      > IMAP.uid_remove_flags(client, 268, [:seen])
+      > IMAP.uid_remove_flags(client, 268..270, [:seen, :flagged])
+  """
+  def uid_remove_flags(pid, uid_or_range, flags, opts \\ []),
+    do: GenServer.call(pid, {:uid_remove_flags, uid_or_range, flags, opts}) && pid
+
+  @doc """
+  Add flags to messages using UIDs instead of sequence numbers.
+
+  ## Examples:
+
+      > IMAP.uid_add_flags(client, 268, [:deleted])
+      > IMAP.uid_add_flags(client, 268..270, [:seen, :flagged])
+  """
+  def uid_add_flags(pid, uid_or_range, flags, opts \\ []),
+    do: GenServer.call(pid, {:uid_add_flags, uid_or_range, flags, opts}) && pid
+
+  @doc """
+  Set flags on messages using UIDs instead of sequence numbers.
+
+  ## Examples:
+
+      > IMAP.uid_set_flags(client, 268, [:seen])
+      > IMAP.uid_set_flags(client, 268..270, [:seen, :flagged])
+  """
+  def uid_set_flags(pid, uid_or_range, flags, opts \\ []),
+    do: GenServer.call(pid, {:uid_set_flags, uid_or_range, flags, opts}) && pid
+
   def copy(pid, sequence, mailbox_name),
     do: GenServer.call(pid, {:copy, sequence, mailbox_name}) && pid
 
@@ -354,6 +387,28 @@ defmodule Mailroom.IMAP do
            "STORE",
            " ",
            to_sequence(sequence),
+           " ",
+           unquote(command),
+           store_silent(opts),
+           " ",
+           flags_to_list(flags)
+         ],
+         %{state | temp: []}
+       )}
+    end
+  end)
+
+  # UID-based flag operations (use UID STORE instead of STORE)
+  [uid_remove_flags: "-FLAGS", uid_add_flags: "+FLAGS", uid_set_flags: "FLAGS"]
+  |> Enum.each(fn {func_name, command} ->
+    def handle_call({unquote(func_name), uid, flags, opts}, from, state) do
+      {:noreply,
+       send_command(
+         from,
+         [
+           "UID STORE",
+           " ",
+           to_sequence(uid),
            " ",
            unquote(command),
            store_silent(opts),
@@ -774,6 +829,14 @@ defmodule Mailroom.IMAP do
   defp process_command_response(
          cmd_tag,
          %{command: "STORE", caller: caller},
+         _msg,
+         %{temp: temp} = state
+       ),
+       do: send_reply(caller, Enum.reverse(temp), remove_command_from_state(state, cmd_tag))
+
+  defp process_command_response(
+         cmd_tag,
+         %{command: "UID STORE", caller: caller},
          _msg,
          %{temp: temp} = state
        ),

--- a/lib/mailroom/inbox.ex
+++ b/lib/mailroom/inbox.ex
@@ -10,7 +10,14 @@ defmodule Mailroom.Inbox do
   end
 
   defmodule MessageContext do
+    @moduledoc """
+    Context passed to email processing callbacks.
+
+    - `id` - The message sequence number (for backwards compatibility)
+    - `uid` - The IMAP UID (unique identifier, stable across sessions)
+    """
     defstruct id: nil,
+              uid: nil,
               type: :imap,
               mail_info: nil,
               mail: nil,
@@ -39,6 +46,7 @@ defmodule Mailroom.Inbox do
       alias Mailroom.IMAP
 
       @matches []
+      @fetch_uid Keyword.get(unquote(opts), :fetch_uid, false)
       @before_compile unquote(__MODULE__)
 
       def init(args) do
@@ -181,9 +189,13 @@ defmodule Mailroom.Inbox do
         {:{}, [], [patterns, module, function, fetch_mail]}
       end)
 
-    fetch_items_required = [
-      :envelope
-      | env.module
+    fetch_uid = Module.get_attribute(env.module, :fetch_uid, false)
+
+    fetch_items_required =
+      [:envelope]
+      |> then(fn items -> if fetch_uid, do: [:uid | items], else: items end)
+      |> Kernel.++(
+        env.module
         |> Module.get_attribute(:matches)
         |> Enum.flat_map(fn %{patterns: patterns} -> patterns end)
         |> Enum.flat_map(fn
@@ -192,7 +204,7 @@ defmodule Mailroom.Inbox do
           _ -> []
         end)
         |> Enum.uniq()
-    ]
+      )
 
     quote location: :keep do
       defp process_mailbox(client, %{assigns: assigns, opts: opts}) do
@@ -275,8 +287,12 @@ defmodule Mailroom.Inbox do
               {mail, message} =
                 if fetch_mail, do: fetch_mail(client, msg_id, opts), else: {nil, nil}
 
+              # Extract UID from mail_info (set by generate_mail_info)
+              uid = Map.get(mail_info, :uid)
+
               context = %MessageContext{
                 id: msg_id,
+                uid: uid,
                 mail_info: mail_info,
                 mail: mail,
                 message: message,

--- a/lib/mailroom/inbox/match_utils.ex
+++ b/lib/mailroom/inbox/match_utils.ex
@@ -109,6 +109,9 @@ defmodule Mailroom.Inbox.MatchUtils do
     {_, subject} =
       Mail.Parsers.RFC2822.parse_header("Subject: #{subject}", parser_opts)
 
+    # Extract UID from response if available
+    uid = Map.get(response, :uid)
+
     %{
       recipients: recipients,
       to: to,
@@ -118,7 +121,8 @@ defmodule Mailroom.Inbox.MatchUtils do
       reply_to: get_email_addresses(reply_to),
       subject: subject,
       has_attachment: has_attachment,
-      headers: headers
+      headers: headers,
+      uid: uid
     }
   end
 

--- a/test/mailroom/imap_test.exs
+++ b/test/mailroom/imap_test.exs
@@ -1450,6 +1450,55 @@ defmodule Mailroom.IMAPTest do
     IMAP.logout(client)
   end
 
+  test "UID STORE" do
+    server = TestServer.start(ssl: true)
+
+    TestServer.expect(server, fn expectations ->
+      expectations
+      |> TestServer.tagged(:connect, "* OK IMAP ready\r\n")
+      |> TestServer.tagged("LOGIN \"test@example.com\" \"P@55w0rD\"\r\n", [
+        "* CAPABILITY (IMAPrev4)\r\n",
+        "OK test@example.com authenticated (Success)\r\n"
+      ])
+      |> TestServer.tagged("SELECT INBOX\r\n", [
+        "* FLAGS (\\Flagged \\Draft \\Deleted \\Seen)\r\n",
+        "* OK [PERMANENTFLAGS (\\Flagged \\Draft \\Deleted \\Seen \\*)] Flags permitted\r\n",
+        "* 2 EXISTS\r\n",
+        "* 1 RECENT\r\n",
+        "OK [READ-WRITE] INBOX selected. (Success)\r\n"
+      ])
+      |> TestServer.tagged("UID STORE 100 -FLAGS (\\Seen)\r\n", [
+        "* 1 FETCH (UID 100 FLAGS ())\r\n",
+        "OK Success\r\n"
+      ])
+      |> TestServer.tagged("UID STORE 101 +FLAGS (\\Answered)\r\n", [
+        "* 2 FETCH (UID 101 FLAGS (\\Answered))\r\n",
+        "OK Success\r\n"
+      ])
+      |> TestServer.tagged("UID STORE 100:101 FLAGS.SILENT (\\Deleted)\r\n", ["OK Success\r\n"])
+      |> TestServer.tagged("LOGOUT\r\n", [
+        "* BYE We're out of here\r\n",
+        "OK Logged out\r\n"
+      ])
+    end)
+
+    assert {:ok, client} =
+             IMAP.connect(server.address, "test@example.com", "P@55w0rD",
+               port: server.port,
+               ssl: true,
+               ssl_opts: [verify: :verify_none],
+               debug: @debug
+             )
+
+    client
+    |> IMAP.select(:inbox)
+    |> IMAP.uid_remove_flags(100, [:seen])
+    |> IMAP.uid_add_flags(101, [:answered])
+    |> IMAP.uid_set_flags(100..101, [:deleted], silent: true)
+
+    IMAP.logout(client)
+  end
+
   test "COPY" do
     server = TestServer.start(ssl: true)
 

--- a/test/mailroom/inbox_test.exs
+++ b/test/mailroom/inbox_test.exs
@@ -604,4 +604,101 @@ defmodule Mailroom.InboxTest do
 
     assert log =~ "Connection failed: :unable_to_connect"
   end
+
+  # Test module with fetch_uid: true option
+  defmodule TestMailProcessorWithUid do
+    def match_with_uid(%{id: msg_id, uid: uid, assigns: %{test_pid: pid}}) do
+      send(pid, {:matched_with_uid, msg_id, uid})
+      :delete
+    end
+  end
+
+  defmodule TestMailRouterWithUid do
+    use Mailroom.Inbox, fetch_uid: true
+
+    def config(opts) do
+      Keyword.merge(opts, username: "test@example.com", password: "P@55w0rD")
+    end
+
+    match do
+      subject(~r/test/i)
+
+      process(TestMailProcessorWithUid, :match_with_uid)
+    end
+
+    def match_to(%{id: msg_id, uid: uid, assigns: %{test_pid: pid}}) do
+      send(pid, {:matched_to_with_uid, msg_id, uid})
+      :delete
+    end
+  end
+
+  test "fetch_uid option includes UID in MessageContext" do
+    server = TestServer.start(ssl: true)
+
+    TestServer.expect(server, fn expectations ->
+      expectations
+      |> TestServer.tagged(:connect, "* OK IMAP ready\r\n")
+      |> TestServer.tagged("LOGIN \"test@example.com\" \"P@55w0rD\"\r\n", [
+        "* CAPABILITY (IMAPrev4)\r\n",
+        "OK test@example.com authenticated (Success)\r\n"
+      ])
+      |> TestServer.tagged("SELECT INBOX\r\n", [
+        "* FLAGS (\\Flagged \\Draft \\Deleted \\Seen)\r\n",
+        "* OK [PERMANENTFLAGS (\\Flagged \\Draft \\Deleted \\Seen \\*)] Flags permitted\r\n",
+        "* 0 EXISTS\r\n",
+        "* 0 RECENT\r\n",
+        "OK [READ-WRITE] INBOX selected. (Success)\r\n"
+      ])
+      |> TestServer.tagged("IDLE\r\n", [
+        "+ idling\r\n",
+        "* 1 EXISTS\r\n"
+      ])
+      |> TestServer.tagged("DONE\r\n", [
+        "OK IDLE terminated\r\n"
+      ])
+      |> TestServer.tagged("SEARCH UNSEEN\r\n", [
+        "* SEARCH 1\r\n",
+        "OK Success\r\n"
+      ])
+      # Note: FETCH includes UID because fetch_uid: true (UID comes first)
+      |> TestServer.tagged("FETCH 1 (UID ENVELOPE)\r\n", [
+        "* 1 FETCH (UID 42 ENVELOPE (\"Wed, 26 Oct 2016 14:23:14 +0200\" \"Test email\" ((\"Bob Jones\" NIL \"bob\" \"example.com\")) ((\"Bob Jones\" NIL \"bob\" \"example.com\")) ((\"Bob Jones\" NIL \"bob\" \"example.com\")) ((\"John Doe\" NIL \"john\" \"example.com\")) NIL NIL NIL \"<B042B704-E13E-44A2-8FEC-67A43B6DD6DB@example.com>\"))\r\n",
+        "OK Success\r\n"
+      ])
+      |> TestServer.tagged("STORE 1 +FLAGS (\\Deleted)\r\n", [
+        "* 1 FETCH (FLAGS (\\Deleted))\r\n",
+        "OK Store completed\r\n"
+      ])
+      |> TestServer.tagged("EXPUNGE\r\n", [
+        "* 1 EXPUNGE\r\n",
+        "OK Expunge completed\r\n"
+      ])
+      |> TestServer.tagged("IDLE\r\n", [
+        "+ idling\r\n"
+      ])
+      |> TestServer.tagged("DONE\r\n", [
+        "OK IDLE terminated\r\n"
+      ])
+      |> TestServer.tagged("LOGOUT\r\n", [
+        "* BYE We're out of here\r\n",
+        "OK Logged out\r\n"
+      ])
+    end)
+
+    ExUnit.CaptureLog.capture_log(fn ->
+      {:ok, pid} =
+        TestMailRouterWithUid.start_link(
+          server: server.address,
+          port: server.port,
+          ssl: true,
+          ssl_opts: [verify: :verify_none],
+          assigns: %{test_pid: self()},
+          debug: @debug
+        )
+
+      # msg_id is 1 (sequence number), uid is 42 (IMAP UID)
+      assert_receive({:matched_with_uid, 1, 42})
+      TestMailRouterWithUid.close(pid)
+    end)
+  end
 end


### PR DESCRIPTION
### Changes

#### New UID flag functions in `Mailroom.IMAP`

- `uid_add_flags/4` - Add flags using `UID STORE` command
- `uid_remove_flags/4` - Remove flags using `UID STORE` command
- `uid_set_flags/4` - Set flags using `UID STORE` command

#### UID in `MessageContext`

- Added `uid` field to `MessageContext` struct
- UID is now fetched alongside envelope data
- `id` field remains unchanged (sequence number) for backwards compatibility

### Motivation

IMAP sequence numbers change when messages are deleted, making them unreliable for identifying emails across operations. UIDs are stable identifiers that persist across sessions, enabling reliable operations like:

- Storing email metadata with a stable identifier
- Deleting specific emails later by UID

### Backwards Compatibility

no breaking changes:
- `MessageContext.id` still contains the sequence number
- Existing code using `id` works unchanged
- `uid` is an additional optional field