### PR TITLE
draft fix for mailroom parsing problem

### DIFF
--- a/lib/mailroom/imap/utils.ex
+++ b/lib/mailroom/imap/utils.ex
@@ -1,20 +1,25 @@
 defmodule Mailroom.IMAP.Utils do
   @moduledoc false
   def parse_list_only(string) do
-    {list, _rest} = parse_list(string)
-    list
+    case parse_list(string) do
+      {:error, _, _} = error -> error
+      {list, _rest} -> list
+    end
   end
 
   def parse_list(string, depth \\ 0, temp \\ nil, acc \\ nil)
 
   def parse_list(<<"(", rest::binary>>, depth, _temp, acc) do
-    {list, rest} = parse_list(rest, depth + 1, nil, [])
-    acc = if acc, do: [list | acc], else: list
+    case parse_list(rest, depth + 1, nil, []) do
+      {:error, _, _} = error -> error
+      {list, rest} ->
+        acc = if acc, do: [list | acc], else: list
 
-    if depth == 0 do
-      {acc, rest}
-    else
-      parse_list(rest, depth, nil, acc)
+        if depth == 0 do
+          {acc, rest}
+        else
+          parse_list(rest, depth, nil, acc)
+        end
     end
   end
 
@@ -23,30 +28,60 @@ defmodule Mailroom.IMAP.Utils do
 
   def parse_list(<<"\"", _rest::binary>> = string, depth, _temp, acc) do
     {string, rest} = parse_string(string)
-    parse_list(rest, depth, string, acc)
+    case parse_list(rest, depth, string, acc) do
+      {:error, _, _} = error -> error
+      result -> result
+    end
   end
 
   def parse_list(<<"{", rest::binary>>, depth, _temp, acc) do
     {octets, <<"\r\n", rest::binary>>} = read_until(rest, "}")
     octets = String.to_integer(octets)
-    <<string::binary-size(octets), rest::binary>> = rest
-    parse_list(rest, depth, nil, prepend_to_list(acc, string))
+
+    if byte_size(rest) >= octets do
+      <<string::binary-size(octets), rest::binary>> = rest
+      parse_list(rest, depth, nil, prepend_to_list(acc, string))
+    else
+      {:error, :incomplete_literal,
+       bytes_needed: octets,
+       bytes_available: byte_size(rest)}
+    end
   end
 
-  def parse_list(<<" ", rest::binary>>, depth, nil, acc),
-    do: parse_list(rest, depth, nil, acc)
+  def parse_list(<<" ", rest::binary>>, depth, nil, acc) do
+    case parse_list(rest, depth, nil, acc) do
+      {:error, _, _} = error -> error
+      result -> result
+    end
+  end
 
-  def parse_list(<<"\r", rest::binary>>, depth, temp, acc),
-    do: parse_list(rest, depth, "\r", prepend_to_list(acc, temp))
+  def parse_list(<<"\r", rest::binary>>, depth, temp, acc) do
+    case parse_list(rest, depth, "\r", prepend_to_list(acc, temp)) do
+      {:error, _, _} = error -> error
+      result -> result
+    end
+  end
 
-  def parse_list(<<" ", rest::binary>>, depth, temp, acc),
-    do: parse_list(rest, depth, nil, prepend_to_list(acc, temp))
+  def parse_list(<<" ", rest::binary>>, depth, temp, acc) do
+    case parse_list(rest, depth, nil, prepend_to_list(acc, temp)) do
+      {:error, _, _} = error -> error
+      result -> result
+    end
+  end
 
-  def parse_list(<<char::utf8, rest::binary>>, depth, nil, acc),
-    do: parse_list(rest, depth, <<char>>, acc)
+  def parse_list(<<char::utf8, rest::binary>>, depth, nil, acc) do
+    case parse_list(rest, depth, <<char>>, acc) do
+      {:error, _, _} = error -> error
+      result -> result
+    end
+  end
 
-  def parse_list(<<char::utf8, rest::binary>>, depth, temp, acc),
-    do: parse_list(rest, depth, <<temp::binary, char>>, acc)
+  def parse_list(<<char::utf8, rest::binary>>, depth, temp, acc) do
+    case parse_list(rest, depth, <<temp::binary, char>>, acc) do
+      {:error, _, _} = error -> error
+      result -> result
+    end
+  end
 
   defp prepend_to_list(nil, item), do: List.wrap(item)
   defp prepend_to_list(list, nil), do: list

--- a/lib/mailroom/imap/utils.ex
+++ b/lib/mailroom/imap/utils.ex
@@ -1,25 +1,22 @@
 defmodule Mailroom.IMAP.Utils do
   @moduledoc false
+  require Logger
+
   def parse_list_only(string) do
-    case parse_list(string) do
-      {:error, _} = error -> error
-      {list, _rest} -> list
-    end
+    {list, _rest} = parse_list(string)
+    list
   end
 
   def parse_list(string, depth \\ 0, temp \\ nil, acc \\ nil)
 
   def parse_list(<<"(", rest::binary>>, depth, _temp, acc) do
-    case parse_list(rest, depth + 1, nil, []) do
-      {:error, _} = error -> error
-      {list, rest} ->
-        acc = if acc, do: [list | acc], else: list
+    {list, rest} = parse_list(rest, depth + 1, nil, [])
+    acc = if acc, do: [list | acc], else: list
 
-        if depth == 0 do
-          {acc, rest}
-        else
-          parse_list(rest, depth, nil, acc)
-        end
+    if depth == 0 do
+      {acc, rest}
+    else
+      parse_list(rest, depth, nil, acc)
     end
   end
 
@@ -28,58 +25,40 @@ defmodule Mailroom.IMAP.Utils do
 
   def parse_list(<<"\"", _rest::binary>> = string, depth, _temp, acc) do
     {string, rest} = parse_string(string)
-    case parse_list(rest, depth, string, acc) do
-      {:error, _} = error -> error
-      result -> result
-    end
+    parse_list(rest, depth, string, acc)
   end
 
   def parse_list(<<"{", rest::binary>>, depth, _temp, acc) do
     {octets, <<"\r\n", rest::binary>>} = read_until(rest, "}")
     octets = String.to_integer(octets)
 
-    if byte_size(rest) >= octets do
-      <<string::binary-size(octets), rest::binary>> = rest
-      parse_list(rest, depth, nil, prepend_to_list(acc, string))
-    else
-      {:error, {:incomplete_literal, bytes_needed: octets, bytes_available: byte_size(rest)}}
+    case rest do
+      <<string::binary-size(octets), rest::binary>> ->
+        parse_list(rest, depth, nil, prepend_to_list(acc, string))
+
+      _ ->
+        Logger.warning("parse_list: expected string of size #{octets} but got #{inspect(rest)}")
+        {acc, rest}
     end
   end
 
-  def parse_list(<<" ", rest::binary>>, depth, nil, acc) do
-    case parse_list(rest, depth, nil, acc) do
-      {:error, _} = error -> error
-      result -> result
-    end
-  end
+  def parse_list(<<" ", rest::binary>>, depth, nil, acc),
+    do: parse_list(rest, depth, nil, acc)
 
-  def parse_list(<<"\r", rest::binary>>, depth, temp, acc) do
-    case parse_list(rest, depth, "\r", prepend_to_list(acc, temp)) do
-      {:error, _} = error -> error
-      result -> result
-    end
-  end
+  def parse_list(<<"\r", rest::binary>>, depth, temp, acc),
+    do: parse_list(rest, depth, "\r", prepend_to_list(acc, temp))
 
-  def parse_list(<<" ", rest::binary>>, depth, temp, acc) do
-    case parse_list(rest, depth, nil, prepend_to_list(acc, temp)) do
-      {:error, _} = error -> error
-      result -> result
-    end
-  end
+  def parse_list(<<" ", rest::binary>>, depth, temp, acc),
+    do: parse_list(rest, depth, nil, prepend_to_list(acc, temp))
 
-  def parse_list(<<char::utf8, rest::binary>>, depth, nil, acc) do
-    case parse_list(rest, depth, <<char>>, acc) do
-      {:error, _} = error -> error
-      result -> result
-    end
-  end
+  def parse_list(<<char::utf8, rest::binary>>, depth, nil, acc),
+    do: parse_list(rest, depth, <<char>>, acc)
 
-  def parse_list(<<char::utf8, rest::binary>>, depth, temp, acc) do
-    case parse_list(rest, depth, <<temp::binary, char>>, acc) do
-      {:error, _} = error -> error
-      result -> result
-    end
-  end
+  def parse_list(<<char::utf8, rest::binary>>, depth, temp, acc),
+    do: parse_list(rest, depth, <<temp::binary, char>>, acc)
+
+  def parse_list(<<>>, _depth, temp, acc),
+    do: {Enum.reverse(prepend_to_list(acc, temp)), <<>>}
 
   defp prepend_to_list(nil, item), do: List.wrap(item)
   defp prepend_to_list(list, nil), do: list

--- a/lib/mailroom/imap/utils.ex
+++ b/lib/mailroom/imap/utils.ex
@@ -2,7 +2,7 @@ defmodule Mailroom.IMAP.Utils do
   @moduledoc false
   def parse_list_only(string) do
     case parse_list(string) do
-      {:error, _, _} = error -> error
+      {:error, _} = error -> error
       {list, _rest} -> list
     end
   end
@@ -11,7 +11,7 @@ defmodule Mailroom.IMAP.Utils do
 
   def parse_list(<<"(", rest::binary>>, depth, _temp, acc) do
     case parse_list(rest, depth + 1, nil, []) do
-      {:error, _, _} = error -> error
+      {:error, _} = error -> error
       {list, rest} ->
         acc = if acc, do: [list | acc], else: list
 
@@ -29,7 +29,7 @@ defmodule Mailroom.IMAP.Utils do
   def parse_list(<<"\"", _rest::binary>> = string, depth, _temp, acc) do
     {string, rest} = parse_string(string)
     case parse_list(rest, depth, string, acc) do
-      {:error, _, _} = error -> error
+      {:error, _} = error -> error
       result -> result
     end
   end
@@ -42,43 +42,41 @@ defmodule Mailroom.IMAP.Utils do
       <<string::binary-size(octets), rest::binary>> = rest
       parse_list(rest, depth, nil, prepend_to_list(acc, string))
     else
-      {:error, :incomplete_literal,
-       bytes_needed: octets,
-       bytes_available: byte_size(rest)}
+      {:error, {:incomplete_literal, bytes_needed: octets, bytes_available: byte_size(rest)}}
     end
   end
 
   def parse_list(<<" ", rest::binary>>, depth, nil, acc) do
     case parse_list(rest, depth, nil, acc) do
-      {:error, _, _} = error -> error
+      {:error, _} = error -> error
       result -> result
     end
   end
 
   def parse_list(<<"\r", rest::binary>>, depth, temp, acc) do
     case parse_list(rest, depth, "\r", prepend_to_list(acc, temp)) do
-      {:error, _, _} = error -> error
+      {:error, _} = error -> error
       result -> result
     end
   end
 
   def parse_list(<<" ", rest::binary>>, depth, temp, acc) do
     case parse_list(rest, depth, nil, prepend_to_list(acc, temp)) do
-      {:error, _, _} = error -> error
+      {:error, _} = error -> error
       result -> result
     end
   end
 
   def parse_list(<<char::utf8, rest::binary>>, depth, nil, acc) do
     case parse_list(rest, depth, <<char>>, acc) do
-      {:error, _, _} = error -> error
+      {:error, _} = error -> error
       result -> result
     end
   end
 
   def parse_list(<<char::utf8, rest::binary>>, depth, temp, acc) do
     case parse_list(rest, depth, <<temp::binary, char>>, acc) do
-      {:error, _, _} = error -> error
+      {:error, _} = error -> error
       result -> result
     end
   end

--- a/test/mailroom/imap/utils_test.exs
+++ b/test/mailroom/imap/utils_test.exs
@@ -46,6 +46,42 @@ defmodule Mailroom.IMAP.UtilsTest do
       assert parse_list("(one two) three") == {["one", "two"], " three"}
       assert parse_list("(one two)\r\n") == {["one", "two"], "\r\n"}
     end
+
+    test "with literal string containing full content" do
+      # Literal with all bytes present inline
+      assert parse_list("(name {5}\r\nhello rest)") == {["name", "hello", "rest"], ""}
+    end
+
+    test "with literal string in nested ENVELOPE structure" do
+      # Simulates a complete IMAP ENVELOPE sender field with literal display name
+      # e.g. ENVELOPE ("date" "subject" (("Display Name" NIL "user" "example.com")) ...)
+      # When the display name contains special chars, the server may use a literal:
+      # (({23}\r\nJohn  Doe - Company Inc NIL "user" "example.com"))
+      # The literal content is exactly 23 bytes: "John  Doe - Company Inc"
+      envelope_sender = "(({23}\r\nJohn  Doe - Company Inc NIL \"user\" \"example.com\"))"
+      {result, _rest} = parse_list(envelope_sender)
+      assert result == [["John  Doe - Company Inc", nil, "user", "example.com"]]
+    end
+
+    test "with literal string where content is truncated (incomplete data)" do
+      # This reproduces the production crash: the IMAP server sends {23}\r\n
+      # but the literal content hasn't arrived yet (split across network packets).
+      # parse_list receives only the header part without the 23 bytes of content.
+      incomplete_data = "(({23}\r\n"
+
+      # The parser should handle this gracefully instead of crashing.
+      # Expected: return an error tuple indicating incomplete data.
+      assert {:error, :incomplete_literal, bytes_needed: 23, bytes_available: 0} =
+               parse_list(incomplete_data)
+    end
+
+    test "with literal string where content is partially present" do
+      # Only 10 of the 23 expected bytes are present
+      partial_data = "(({23}\r\nJohn  Doe "
+
+      assert {:error, :incomplete_literal, bytes_needed: 23, bytes_available: 10} =
+               parse_list(partial_data)
+    end
   end
 
   test "parse_list_only/1" do

--- a/test/mailroom/imap/utils_test.exs
+++ b/test/mailroom/imap/utils_test.exs
@@ -70,17 +70,30 @@ defmodule Mailroom.IMAP.UtilsTest do
       incomplete_data = "(({23}\r\n"
 
       # The parser should handle this gracefully instead of crashing.
-      # Expected: return an error tuple indicating incomplete data.
-      assert {:error, {:incomplete_literal, bytes_needed: 23, bytes_available: 0}} =
-               parse_list(incomplete_data)
+      # Expected: return partial data and log a warning.
+      import ExUnit.CaptureLog
+
+      log =
+        capture_log(fn ->
+          assert {[[]], ""} = parse_list(incomplete_data)
+        end)
+
+      assert log =~ "parse_list: expected string of size 23"
     end
 
     test "with literal string where content is partially present" do
       # Only 10 of the 23 expected bytes are present
+      # The parser returns the accumulated list and continues parsing the rest as tokens
       partial_data = "(({23}\r\nJohn  Doe "
 
-      assert {:error, {:incomplete_literal, bytes_needed: 23, bytes_available: 10}} =
-               parse_list(partial_data)
+      import ExUnit.CaptureLog
+
+      log =
+        capture_log(fn ->
+          assert {[[], "John", "Doe"], ""} = parse_list(partial_data)
+        end)
+
+      assert log =~ "parse_list: expected string of size 23"
     end
   end
 

--- a/test/mailroom/imap/utils_test.exs
+++ b/test/mailroom/imap/utils_test.exs
@@ -71,7 +71,7 @@ defmodule Mailroom.IMAP.UtilsTest do
 
       # The parser should handle this gracefully instead of crashing.
       # Expected: return an error tuple indicating incomplete data.
-      assert {:error, :incomplete_literal, bytes_needed: 23, bytes_available: 0} =
+      assert {:error, {:incomplete_literal, bytes_needed: 23, bytes_available: 0}} =
                parse_list(incomplete_data)
     end
 
@@ -79,7 +79,7 @@ defmodule Mailroom.IMAP.UtilsTest do
       # Only 10 of the 23 expected bytes are present
       partial_data = "(({23}\r\nJohn  Doe "
 
-      assert {:error, :incomplete_literal, bytes_needed: 23, bytes_available: 10} =
+      assert {:error, {:incomplete_literal, bytes_needed: 23, bytes_available: 10}} =
                parse_list(partial_data)
     end
   end

--- a/test/mailroom/imap_test.exs
+++ b/test/mailroom/imap_test.exs
@@ -1351,6 +1351,51 @@ defmodule Mailroom.IMAPTest do
     IMAP.logout(client)
   end
 
+  test "FETCH with data and not enough data to complete the response" do
+    server = TestServer.start(ssl: true)
+
+    TestServer.expect(server, fn expectations ->
+      expectations
+      |> TestServer.tagged(:connect, "* OK IMAP ready\r\n")
+      |> TestServer.tagged("LOGIN \"test@example.com\" \"P@55w0rD\"\r\n", [
+        "* CAPABILITY (IMAPrev4)\r\n",
+        "OK test@example.com authenticated (Success)\r\n"
+      ])
+      |> TestServer.tagged("SELECT INBOX\r\n", [
+        "* FLAGS (\\Flagged \\Draft \\Deleted \\Seen)\r\n",
+        "* OK [PERMANENTFLAGS (\\Flagged \\Draft \\Deleted \\Seen \\*)] Flags permitted\r\n",
+        "* 2 EXISTS\r\n",
+        "* 1 RECENT\r\n",
+        "OK [READ-WRITE] INBOX selected. (Success)\r\n"
+      ])
+      |> TestServer.tagged("FETCH 1 (ENVELOPE)\r\n", [
+        "* 1 FETCH (ENVELOPE (\"Tue, 3 Mar 2026 15:32:29 +0000\" \"Rechnungen\" (({23}\r\n",
+        "OK Success\r\n"
+      ])
+      |> TestServer.tagged("LOGOUT\r\n", [
+        "* BYE We're out of here\r\n",
+        "OK Logged out\r\n"
+      ])
+    end)
+
+    assert {:ok, client} =
+             IMAP.connect(server.address, "test@example.com", "P@55w0rD",
+               port: server.port,
+               ssl: true,
+               ssl_opts: [verify: :verify_none],
+               debug: @debug
+             )
+
+    {:ok, msgs} =
+      client
+      |> IMAP.select(:inbox)
+      |> IMAP.fetch(1, :envelope)
+
+    assert msgs == [{1, %{envelope: :error}}]
+
+    IMAP.logout(client)
+  end
+
   test "FETCH with extra (unrequested) information returned" do
     server = TestServer.start(ssl: true)
 


### PR DESCRIPTION
**Problem**
The mailroom IMAP parser is crashing in production when processing emails with literal strings that arrive in fragmented network packets. This causes GenServer termination and prevents email processing.

**Effect**: GenServer crashes prevent all email processing
**Frequency**: Occurs whenever literal strings span network packet boundaries. For a given email from a given email server, it happens every time the email is processed.

**Error**
** (MatchError) no match of right hand side value: ""
    (mailroom 0.7.0) lib/mailroom/imap/utils.ex:32: Mailroom.IMAP.Utils.parse_list/4
Triggering message:

"* 15920 FETCH (UID 28376 ENVELOPE (\"Tue, 3 Mar 2026 15:32:29 +0000\" \"Rechnungen\" (({23}\r\n"
Problematic email: From "Ceabtise Nzisch - YZMAK" [c.nzisch@yzmak-inmotitien.ch](mailto:c.nzisch@yzmak-inmotilten.ch)

**Root Cause**
The parser at lib/mailroom/imap/utils.ex:29-34 assumes complete data when parsing IMAP literal strings:

**Issue**:

* MAP server sends literal header: {23}\r\n (indicating 23 bytes will follow)
* Network packet ends before the literal content arrives
* Parser receives rest = "" (empty buffer)
* Pattern match <<string::binary-size(23), rest::binary>> = "" fails
* MatchError - cannot extract 23 bytes from empty string


**Secondary Issue**: Byte Count Mismatch
The IMAP server in production declared {23} bytes but the actual sender name was 24 bytes. This suggests:

What should be the correct response when IMAP server has a bug?